### PR TITLE
Exclude unneeded files from jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,13 @@ production_url : "http://jser.info"
 github_repo_url : https://github.com/jser/jser.github.io
 timezone: Asia/Tokyo
 encoding: utf-8
-exclude: ["README.md"]
+exclude:
+  - "README.md"
+  - "Gemfile"
+  - "LICENSE"
+  - "bower.json"
+  - "import.sh"
+  - "package.json"
 # Setup
 author:
   name: 'azu'


### PR DESCRIPTION
`_config.yml`にて, excludeしていない`Gemfile`といった必要のないファイルに
アクセス出来るようになっていたので修正しました

http://jser.info/Gemfile
http://jser.info/package.json
