### PR TITLE
remove an already introduced entry

### DIFF
--- a/_posts/2015/2015-06-02-Angular1.4.0-Polymer1.0.md
+++ b/_posts/2015/2015-06-02-Angular1.4.0-Polymer1.0.md
@@ -132,15 +132,6 @@ ES6で書いたコードに対するテストをES6とpower-assertで書いて�
 
 ----
 
-## Moving to ES6 from CoffeeScript
-[gist.github.com/danielgtaylor/0b60c2ed1f069f118562](https://gist.github.com/danielgtaylor/0b60c2ed1f069f118562 "Moving to ES6 from CoffeeScript")
-
-<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">CoffeeScript</span></p>
-
-CoffeeScriptからES6への移行において文法の比較やES6の構文や機能の紹介
-
-----
-
 ## WebGL 軽量ライブラリを比較してみる - Qiita
 [qiita.com/cx20/items/0fa19c96aa6470d98807](http://qiita.com/cx20/items/0fa19c96aa6470d98807 "WebGL 軽量ライブラリを比較してみる - Qiita")
 


### PR DESCRIPTION
「[2015-06-02のJS](http://jser.info/2015/06/02/Angular1.4.0-Polymer1.0/)」の「[Moving to ES6 from CoffeeScript](http://jser.info/2015/06/02/Angular1.4.0-Polymer1.0/#moving-to-es6-from-coffeescript)」は、「[2015-05-27のJS](http://jser.info/2015/05/27/promise-angular2/)」で[既に紹介されています](http://jser.info/2015/05/27/promise-angular2/#moving-to-es6-from-coffeescript)ので、不要と思われる「2015-06-02のJS」の方を削除してみました。