### PR TITLE
fix(page): aboutページをpageからpostへ変更

### DIFF
--- a/_i18n/ja.yml
+++ b/_i18n/ja.yml
@@ -6,7 +6,6 @@ titles:
   article: 投稿一覧
   page: ページ
   newest: 最近の投稿
-  about: JSer.infoについて
 date:
   year: 年
   month: 月

--- a/_i18n/ja/_posts/about/2015-06-10-about.md
+++ b/_i18n/ja/_posts/about/2015-06-10-about.md
@@ -1,3 +1,9 @@
+---
+layout: post
+title: JSer.infoについて
+permalink: /about/
+---
+
 このサイトについて。
 
 [JSer.info](http://jser.info/ "JSer.info")は世界中言語問わずJavaScriptの情報を紹介していくサイトです。

--- a/_i18n/ko.yml
+++ b/_i18n/ko.yml
@@ -6,7 +6,6 @@ titles:
   article: 글 목록
   page: 페이지
   newest: 최신 글
-  about: JSer.info 소개
 date:
   year: 년
   month: 월

--- a/_i18n/ko/_posts/about/2015-06-10-about.md
+++ b/_i18n/ko/_posts/about/2015-06-10-about.md
@@ -1,3 +1,9 @@
+---
+layout: post
+title: JSer.info 소개
+permalink: /about/
+---
+
 이 사이트에 관하여.
 
 [JSer.info](http://jser.info/ "JSer.info")는 전세계 언어 구별없이 JavaScript 소식을 소개하는 사이트입니다.

--- a/about.md
+++ b/about.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: titles.about
-permalink: /about/
----
-
-{% tf about.md %}


### PR DESCRIPTION
 #93 に関連するaboutページの修正です。
`title: page.title` の翻訳がプラグインの仕組み的に難しいため、`about.md`をpage typeからpost typeに変更しました。

- URL自体は同じで、記事ファイル自体にtitleを直接書くように変更しました
- 通常の記事と同じlayout:postに変更

page typeは殆ど使ってないので、aboutページだけのために色々工夫するよりは([Multiple Languages in Jekyll](https://github.com/screeninteraction/jekyll-multiple-languages-plugin "Multiple Languages in Jekyll")的にも難しそう)、通常の記事と同じ仕組で翻訳すると問題が少なくて良いと思います。

Before:

`<title>` 要素の中身にkeyそのものが表示されてしまってる

![2015-06-10 14-29-44](https://cloud.githubusercontent.com/assets/19714/8075733/ca0c7a62-0f7e-11e5-8ae7-b843aa38ce69.png)

After: 

![index html 2015-06-10 14-41-48](https://cloud.githubusercontent.com/assets/19714/8075737/d64a9db8-0f7e-11e5-9637-e38fd31a5fe5.png)

/cc @UYEONG 
