### PR TITLE
Revise the summary about ServiceWorker changes

### DIFF
--- a/_i18n/ja/_posts/2015/2015-07-28-title.md
+++ b/_i18n/ja/_posts/2015/2015-07-28-title.md
@@ -57,7 +57,7 @@ Babelにも同梱されてるES5、ES6、ES.nextのpolyfillであるcore-js 1.0.
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">Chrome</span> <span class="jser-tag">ReleaseNote</span></p>
 
 Chrome 45 Betaリリース。
-Arrow FunctionやObject.assignなどのサポート、Subresource Integrityのサポート、SVGアニメーションを行うSMILを非推奨に、ServiceWorkerへpostMessageでメッセージをやりとりできるようになるなど
+Arrow FunctionやObject.assignなどのサポート、Subresource Integrityのサポート、SVGアニメーションを行うSMILを非推奨に、ServiceWorkerからページへpostMessageしたときのメッセージ配送先オブジェクトの変更など
 
 - [Subresource Integrity Sample](https://googlechrome.github.io/samples/subresource-integrity/index.html "Subresource Integrity Sample")
 


### PR DESCRIPTION
ページと Service Worker の間での postMessage は以前からできていましたが、今回のバージョンアップでページから Service Worker へ postMessage したときのメッセージ配送先が window から navigator.serviceWorker に変更されました。