### PR TITLE
fix a duplicated link

### DIFF
--- a/_i18n/ja/_posts/2016/2016-01-20-jquery3beta-esnext-news-chkracore.md
+++ b/_i18n/ja/_posts/2016/2016-01-20-jquery3beta-esnext-news-chkracore.md
@@ -126,7 +126,7 @@ ES.nextについての週刊メルマガ。
 JavaScriptの補完的な感じ。
 by Dr.Axel Rauschmayer and Johannes Weber.
 
-- [ES.next News: The 5 best ECMAScript links of the week](http://esnextnews.com/ "ES.next News: The 5 best ECMAScript links of the week")
+- [ES.next News: a weekly email newsletter](http://www.2ality.com/2016/01/esnext-news.html "ES.next News: a weekly email newsletter")
 
 ----
 


### PR DESCRIPTION
「[ES.next News: The 5 best ECMAScript links of the week](http://esnextnews.com/)」の項目の関連リンクについて、項目のリンクと重複していると思われるリンクがありましたので修正しました。