### PR TITLE
Math.randomのアルゴリズム XorShift128+

### DIFF
--- a/_i18n/ja/_posts/2016/2016-01-27-math.random-xsfhit.md
+++ b/_i18n/ja/_posts/2016/2016-01-27-math.random-xsfhit.md
@@ -1,0 +1,12 @@
+---
+title: "ブラウザのMath.random()のアルゴリズムがXorShift128+になった"
+author: azu
+layout: post
+date : 2016-01-27T11:32
+category: Browser
+tags:
+    - JavaScript
+    - Brwoser
+
+---
+

--- a/_i18n/ja/_posts/2016/2016-01-27-math.random-xsfhit.md
+++ b/_i18n/ja/_posts/2016/2016-01-27-math.random-xsfhit.md
@@ -10,3 +10,35 @@ tags:
 
 ---
 
+JavaScriptで擬似乱数を返す`Math.random()`のアルゴリズムが最近XorShift128+にシフトしています。
+[メジャーブラウザ](https://github.com/azu/browser-javascript-resource)のJavaScriptエンジンは全て変更されていたので、まとめておきます。
+
+## Chrome/V8
+
+- [V8 JavaScript Engine: There's Math.random(), and then there's Math.random()](http://v8project.blogspot.jp/2015/12/theres-mathrandom-and-then-theres.html "V8 JavaScript Engine: There&#39;s Math.random(), and then there&#39;s Math.random()")
+
+[Chrome 49 Stable](http://v8project.blogspot.jp/2016/01/v8-release-49.html "Chrome 49 Stable")で入る予定。
+
+## Firefox/SpiderMonkey
+
+- [SpiderMonkey](https://bugzilla.mozilla.org/show_bug.cgi?id=322529 "SpiderMonkey")
+- 
+## WebKit/JavaScriptCore
+
+- [Bug 151641 – Use a better RNG for Math.random()](https://bugs.webkit.org/show_bug.cgi?id=151641 "Bug 151641 – Use a better RNG for Math.random()")
+
+## MSEdge/ChakraCore
+
+- [Update Math.random to use xorshift128+ by suwc · Pull Request #145 · Microsoft/ChakraCore](https://github.com/Microsoft/ChakraCore/pull/145 "Update Math.random to use xorshift128+ by suwc · Pull Request #145 · Microsoft/ChakraCore")
+
+## アルゴリズム
+
+- [Google Chromeが採用した、擬似乱数生成アルゴリズム「xorshift」の数理 – びりあるの研究ノート](https://blog.visvirial.com/articles/575 "Google Chromeが採用した、擬似乱数生成アルゴリズム「xorshift」の数理 – びりあるの研究ノート")
+
+## 仕様
+
+- [ECMAScript® 2016 Language Specification](https://tc39.github.io/ecma262/#sec-math.random "ECMAScript® 2016 Language Specification")
+
+> Returns a Number value with positive sign, greater than or equal to 0 but less than 1, chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an implementation-dependent algorithm or strategy. This function takes no arguments.
+
+仕様では"実装依存のアルゴリズムで"と書いてあるので、特に`Math.random()`のアルゴリズムは規定されていません。


### PR DESCRIPTION
- [Update Math.random to use xorshift128+ by suwc · Pull Request #145 · Microsoft/ChakraCore](https://github.com/Microsoft/ChakraCore/pull/145 "Update Math.random to use xorshift128+ by suwc · Pull Request #145 · Microsoft/ChakraCore")
- [V8 JavaScript Engine: There's Math.random(), and then there's Math.random()](http://v8project.blogspot.jp/2015/12/theres-mathrandom-and-then-theres.html)
- [322529 – Upgrade Math.random() to the better XorShift128+ algorithm](https://bugzilla.mozilla.org/show_bug.cgi?id=322529)
- [Math.random() and 32-bit precision](http://jandemooij.nl/blog/2015/11/27/math-random-and-32-bit-precision/)
- [Bug 151641 – Use a better RNG for Math.random()](https://bugs.webkit.org/show_bug.cgi?id=151641)
- [Google Chromeが採用した、擬似乱数生成アルゴリズム「xorshift」の数理 – びりあるの研究ノート](https://blog.visvirial.com/articles/575)
