### PR TITLE
`Array.prototype.includes`が策定された時期をES 2016以降に修正

### DIFF
--- a/_i18n/ja/_posts/2016/2016-08-15-chrome-53-beta60fps-css-animation.md
+++ b/_i18n/ja/_posts/2016/2016-08-15-chrome-53-beta60fps-css-animation.md
@@ -32,7 +32,7 @@ PaymentRequest APIのサポート、[Safariと同様](https://webkit.org/blog/67
 ----
 
 [Make your JavaScript code shine: knockout old ES5 hacks](https://rainsoft.io/make-your-javascript-code-shide-knockout-old-es5-hack/)という記事では、既に代替表現があるES5以下のコードについて書かれています。
-ES2015以降では`indexOf !== -1`ではなく`includes`が利用できるなど、ES2015ではこれまでのイディオムをより明示的に表現する[方法が多く](https://github.com/asciidwango/js-primer/issues/108)あります。
+ES2016以降では`indexOf !== -1`ではなく`includes`が利用できるなど、ES2015以降ではこれまでのイディオムをより明示的に表現する[方法が多く](https://github.com/asciidwango/js-primer/issues/108)あります。
 
 この記事では、それらについてどういうイディオムなのかと代わりにどう書けるのかが分かりやすく書かれています。
 


### PR DESCRIPTION
[元の記事](https://rainsoft.io/make-your-javascript-code-shide-knockout-old-es5-hack/#1verifytheelementexistenceinanarray)にも記載ありますが`Array.prototype.includes`はES 2016以降に策定されたものです。

周辺の部分を含めて即した文書に書き換えました。