### PR TITLE
2016-10-24のJavaScript

### DIFF
--- a/_i18n/ja/_posts/2016/2016-10-24-npm-4.0.0-node.js-v6.9.0-lts-webpack2.md
+++ b/_i18n/ja/_posts/2016/2016-10-24-npm-4.0.0-node.js-v6.9.0-lts-webpack2.md
@@ -1,0 +1,275 @@
+---
+title: "2016-10-24のJS: npm 4.0.0、Node.js v6.9.0 (LTS)、webpack@2へのマイグレーション"
+author: azu
+layout: post
+date : 2016-10-24T09:36
+category: JSer
+tags:
+    - npm
+    - Node.js
+    - webpack
+
+---
+
+JSer.info #302
+
+----
+<h1 class="site-genre">ヘッドライン</h1>
+
+----
+
+## Release v4.0.0 · npm/npm
+[github.com/npm/npm/releases/tag/v4.0.0](https://github.com/npm/npm/releases/tag/v4.0.0 "Release v4.0.0 · npm/npm")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">npm</span> <span class="jser-tag">ReleaseNote</span></p>
+
+npm v4 Preリリース
+`npm i -g npm@4`でインストールができるように、`npm search`の速度改善、`publish`ライフサイクルがdepreated、代わりに`prepare`や`prepublishOnly`が利用可能に、
+`npm tag`が削除など
+
+- [node-gakuen-201610.md](https://gist.github.com/othiym23/c98bd4ef5d9fb3f496835bd481ef40ae "node-gakuen-201610.md")
+- [$ npm search npm # on npm@4](https://twitter.com/azu_re/status/789985478065790976 "$ npm search npm # on npm@4")
+
+----
+
+## Release JSHint 2.9.4 · jshint/jshint
+[github.com/jshint/jshint/releases/tag/2.9.4](https://github.com/jshint/jshint/releases/tag/2.9.4 "Release JSHint 2.9.4 · jshint/jshint")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">Tools</span> <span class="jser-tag">ReleaseNote</span></p>
+
+JSHint 2.9.4リリース。
+TDZの対応、重複したエラー報告をしないようになるなど
+
+----
+
+## Ember.js - Ember.js 2.8-LTS, 2.9 and 2.10 Beta Released
+[emberjs.com/blog/2016/10/17/ember-2-9-released.html](http://emberjs.com/blog/2016/10/17/ember-2-9-released.html "Ember.js - Ember.js 2.8-LTS, 2.9 and 2.10 Beta Released")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span> <span class="jser-tag">ReleaseNote</span></p>
+
+Ember.js 2.8-LTS、2.9、2.10β リリース。
+2.8-LTSでは2018年2月までセキュリティパッチがリリースされる。
+
+----
+
+## flux/CHANGELOG.md at 3.1.0 · facebook/flux
+[github.com/facebook/flux/blob/3.1.0/CHANGELOG.md](https://github.com/facebook/flux/blob/3.1.0/CHANGELOG.md "flux/CHANGELOG.md at 3.1.0 · facebook/flux")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">facebook</span> <span class="jser-tag">Flux</span> <span class="jser-tag">library</span> <span class="jser-tag">ReleaseNote</span></p>
+
+Facebook/flux 3.0.0リリース。
+`FluxMapStore`を削除
+
+----
+
+## Chromium Blog: Chrome 55 Beta: Input handling improvements and async/await functions
+[blog.chromium.org/2016/10/chrome-55-beta-input-handling.html](https://blog.chromium.org/2016/10/chrome-55-beta-input-handling.html "Chromium Blog: Chrome 55 Beta: Input handling improvements and async/await functions")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">Chrome</span> <span class="jser-tag">ReleaseNote</span></p>
+
+Chrome 55 Betaリリース。
+Pointer Events、async/await、CSS `hyphens`、Persistent Storageのサポートなど
+corss originでかつ2G回線における`document.write`をブロックするようになるなど
+
+----
+
+## Node v6.9.0 (LTS) | Node.js
+[nodejs.org/en/blog/release/v6.9.0/](https://nodejs.org/en/blog/release/v6.9.0/ "Node v6.9.0 (LTS) | Node.js")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">node.js</span> <span class="jser-tag">ReleaseNote</span></p>
+
+Node.js v6.9.0 (LTS)リリース。
+Node.js v4.x (LTS)からのマイグレーションガイドも書かれている。
+v6.xは2018年4月までアクティブなLTSとなる。
+
+- [Node.js v6 Transitions to LTS – Medium](https://medium.com/@nodejs/node-js-v6-transitions-to-lts-be7f18c17159 "Node.js v6 Transitions to LTS – Medium")
+
+----
+<h1 class="site-genre">アーティクル</h1>
+
+----
+
+## Node.js v6 Transitions to LTS – Medium
+[medium.com/@nodejs/node-js-v6-transitions-to-lts-be7f18c17159](https://medium.com/@nodejs/node-js-v6-transitions-to-lts-be7f18c17159 "Node.js v6 Transitions to LTS – Medium")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">node.js</span></p>
+
+Node.js v6以降のLTSスケジュールについて
+Node.js v0.10/v0.12は2016年12月でEOLとなる。
+
+----
+
+## auxclick is Coming to Chrome 55  |  Web  |  Google Developers
+[developers.google.com/web/updates/2016/10/auxclick](https://developers.google.com/web/updates/2016/10/auxclick "auxclick is Coming to Chrome 55  |  Web  |  Google Developers")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">Chrome</span> <span class="jser-tag">JavaScript</span></p>
+
+左クリック以外に反応する`clicK`イベントである`auxclick`イベントについて。
+
+----
+
+## Once Upon an Event Listener  |  Web  |  Google Developers
+[developers.google.com/web/updates/2016/10/addeventlistener-once](https://developers.google.com/web/updates/2016/10/addeventlistener-once "Once Upon an Event Listener  |  Web  |  Google Developers")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">DOM</span></p>
+
+`HTMLElement#addEventListener`の`{once}`オプションについて。
+一度のみハンドリングするハンドラを指定できる
+
+----
+
+## Migrating to Webpack 2
+[javascriptplayground.com/blog/2016/10/moving-to-webpack-2/](http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/ "Migrating to Webpack 2")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">webpack</span> <span class="jser-tag">document</span></p>
+
+webpack@1から@2へのマイグレーションについて
+
+- [How to Upgrade from Webpack 1?](https://webpack.js.org/how-to/upgrade-from-webpack-1/ "How to Upgrade from Webpack 1?")
+
+----
+
+## Async functions - making promises friendly  |  Web  |  Google Developers
+[developers.google.com/web/fundamentals/getting-started/primers/async-functions](https://developers.google.com/web/fundamentals/getting-started/primers/async-functions "Async functions - making promises friendly  |  Web  |  Google Developers")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span></p>
+
+async/awaitについて。
+sequentialとparallelな書き方の違いについてサンプルコードと共に解説してる
+
+----
+
+## Tips for using async functions (ES2017)
+[www.2ality.com/2016/10/async-function-tips.html](http://www.2ality.com/2016/10/async-function-tips.html "Tips for using async functions (ES2017)")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span></p>
+
+async/awaitの細かな注意点について。
+asyncの動作、awaitを忘れた場合の動画、`await Promise.all()`、コールバックとasync、unhandled rejectionについて
+
+----
+
+## TestCafeでブラウザの自動テスト(E2Eテスト) | Web Scratch
+[efcl.info/2016/10/23/testcafe/](http://efcl.info/2016/10/23/testcafe/ "TestCafeでブラウザの自動テスト(E2Eテスト) | Web Scratch")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">browser</span> <span class="jser-tag">testing</span> <span class="jser-tag">E2E</span></p>
+
+ブラウザの自動テストフレームワークであるTestCafeの使い方についての解説。
+設定レスで動作する仕組み、リモートテスト、テストコードについて
+
+----
+
+## Syntax: language agnostic parser generator – Medium
+[medium.com/@DmitrySoshnikov/syntax-language-agnostic-parser-generator-bd24468d7cfc](https://medium.com/@DmitrySoshnikov/syntax-language-agnostic-parser-generator-bd24468d7cfc "Syntax: language agnostic parser generator – Medium")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
+
+言語を問わないagnosticなパーサ、ジェネレータツールキット
+
+- [DmitrySoshnikov/syntax: Syntactic analysis toolkit for education, tracing the parsing process, and parsers generation.](https://github.com/DmitrySoshnikov/syntax "DmitrySoshnikov/syntax: Syntactic analysis toolkit for education, tracing the parsing process, and parsers generation.")
+
+----
+
+## Pragmatic, Practical, and Progressive Theming with Custom Properties – CSS Wizardry – CSS, OOCSS, front-end architecture, performance and more, by Harry Roberts
+[csswizardry.com/2016/10/pragmatic-practical-progressive-theming-with-custom-properties/](http://csswizardry.com/2016/10/pragmatic-practical-progressive-theming-with-custom-properties/ "Pragmatic, Practical, and Progressive Theming with Custom Properties – CSS Wizardry – CSS, OOCSS, front-end architecture, performance and more, by Harry Roberts")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">CSS</span></p>
+
+CSS Custom Propertyを使ったテーマの実装
+
+----
+<h1 class="site-genre">スライド、動画関係</h1>
+
+----
+
+## Polymer Summit 2016 - YouTube
+[www.youtube.com/playlist?list=PLNYkxOF6rcICc687SxHQRuo9TVNOJelSZ](https://www.youtube.com/playlist?list=PLNYkxOF6rcICc687SxHQRuo9TVNOJelSZ "Polymer Summit 2016 - YouTube")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">WebComponents</span> <span class="jser-tag">イベント</span></p>
+
+Polymer Summit 2016の動画一覧
+
+- [Polymer Summit 2016](https://www.polymer-project.org/summit "Polymer Summit 2016")
+
+----
+<h1 class="site-genre">サイト、サービス、ドキュメント</h1>
+
+----
+
+## A JavaScript library for building user interfaces - React
+[facebook.github.io/react/](https://facebook.github.io/react/ "A JavaScript library for building user interfaces - React")
+
+Reactのドキュメントが新しくなった。
+Codepenでサンプルを実行できるように
+
+- [Dan Abramov on Twitter: &amp;#34;New React docs are live! Featuring all-new guides written from scratch, ES6 examples, and CodePen snippets. https://t.co/cNZZC1vVZc https://t.co/8cZCO1W5pG&amp;#34;](https://twitter.com/dan_abramov/status/789573515750076417 "Dan Abramov on Twitter: &amp;#34;New React docs are live! Featuring all-new guides written from scratch, ES6 examples, and CodePen snippets. https://t.co/cNZZC1vVZc https://t.co/8cZCO1W5pG&amp;#34;")
+
+----
+
+## jsPerf: JavaScript performance playground
+[jsperf.com/](https://jsperf.com/ "jsPerf: JavaScript performance playground")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">performance</span> <span class="jser-tag">webservice</span></p>
+
+JavaScriptスニペットのパフォーマンス計測サービスであるjsPerfのリニューアル公開
+
+----
+<h1 class="site-genre">ソフトウェア、ツール、ライブラリ関係</h1>
+
+----
+
+## beautify-web/js-beautify · GitHub
+[github.com/beautify-web/js-beautify](https://github.com/beautify-web/js-beautify "beautify-web/js-beautify · GitHub")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">Tools</span></p>
+
+JavaScriptを整形できるツールとサイト。 `.jsbeautifyrc`で設定を管理できる
+
+----
+
+## jgraph/mxgraph: mxGraph is a fully client side JavaScript diagramming library
+[github.com/jgraph/mxgraph](https://github.com/jgraph/mxgraph "jgraph/mxgraph: mxGraph is a fully client side JavaScript diagramming library")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">SVG</span> <span class="jser-tag">library</span></p>
+
+draw.ioで使われているSVGの作図ライブラリ。
+
+- [JavaScript Diagram Editor](https://jgraph.github.io/mxgraph/javascript/ "JavaScript Diagram Editor")
+- [jgraph/draw.io: Source to www.draw.io](https://github.com/jgraph/draw.io "jgraph/draw.io: Source to www.draw.io")
+
+----
+
+## Automated browser testing for the modern web development stack | TestCafe
+[devexpress.github.io/testcafe/](http://devexpress.github.io/testcafe/ "Automated browser testing for the modern web development stack | TestCafe")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">testing</span> <span class="jser-tag">E2E</span></p>
+
+設定なしで使える自動テストフレームワーク。
+Seleniumを使わないので単独で動作する。
+Babelを内蔵しasync/awaitなどを扱え、自動的に一定時間待つなどの仕組みを持っている。
+
+- [TestCafeでブラウザの自動テスト(E2Eテスト) | Web Scratch](http://efcl.info/2016/10/23/testcafe/ "TestCafeでブラウザの自動テスト(E2Eテスト) | Web Scratch")
+- [Why not use Selenium? - Questions - TestCafe Discussion Board](https://testcafe-discuss.devexpress.com/t/why-not-use-selenium/47/2 "Why not use Selenium? - Questions - TestCafe Discussion Board")
+
+----
+
+## Hyperform - Capture form validation back from the browser
+[hyperform.js.org/](https://hyperform.js.org/ "Hyperform - Capture form validation back from the browser")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
+
+HTML 5 form validation APIをpolyfill/置き換える実装を持つフォームバリデーションライブラリ
+
+----
+<h1 class="site-genre">書籍関係</h1>
+
+----
+
+## JavaScript フレームワーク入門 : 掌田津耶乃 : 本 : Amazon.co.jp
+[www.amazon.co.jp/JavaScript-%E3%83%95%E3%83%AC%E3%83%BC%E3%83%A0%E3%83%AF%E3%83%BC%E3%82%AF%E5%85%A5%E9%96%80-%E6%8E%8C%E7%94%B0%E6%B4%A5%E8%80%B6%E4%B9%83/dp/4798047848](https://www.amazon.co.jp/JavaScript-%E3%83%95%E3%83%AC%E3%83%BC%E3%83%A0%E3%83%AF%E3%83%BC%E3%82%AF%E5%85%A5%E9%96%80-%E6%8E%8C%E7%94%B0%E6%B4%A5%E8%80%B6%E4%B9%83/dp/4798047848 "JavaScript フレームワーク入門 : 掌田津耶乃 : 本 : Amazon.co.jp")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span> <span class="jser-tag">book</span></p>
+
+TypeScript、npmとBower、webpack、jQuery、Vue.js、Backbone.js、Angular、React、AureliaなどのJavaScriptの色々なツールやフレームワークについての本
+
+----

--- a/_i18n/ja/_posts/2016/2016-10-24-npm-4.0.0-node.js-v6.9.0-lts-webpack2.md
+++ b/_i18n/ja/_posts/2016/2016-10-24-npm-4.0.0-node.js-v6.9.0-lts-webpack2.md
@@ -11,7 +11,54 @@ tags:
 
 ---
 
-JSer.info #302
+JSer.info #302 - npm 4.0.0がプレリリースされました。
+
+- [Release v4.0.0 · npm/npm](https://github.com/npm/npm/releases/tag/v4.0.0 "Release v4.0.0 · npm/npm")
+
+```
+npm install -g npm@4
+```
+
+でインストールすることができます。
+`npm search`の速度改善、`publish`ライフサイクルがdepreatedとなり、代わりに`prepare`や`prepublishOnly`が利用可能になるなど。
+`npm tag`が`npm dist-tag`となり、`npm outdated`がexit statusを正しく返すなどの変更が含まれています。
+
+
+----
+
+[Node.js v6.9.0 (LTS)](https://nodejs.org/en/blog/release/v6.9.0/ "Node v6.9.0 (LTS) | Node.js")がリリースされました。
+
+6.xのLTS版となり、詳しいサポートスケジュールは以下の記事で解説されています。
+
+- [Node.js v6 Transitions to LTS – Medium](https://medium.com/@nodejs/node-js-v6-transitions-to-lts-be7f18c17159#.c8d2tljbn "Node.js v6 Transitions to LTS – Medium")
+
+Node.js v0.10/v0.12は2016年12月でサポートが終了となり、
+Node.js v4.xは2017年4月からメンテンスモードとなります。
+
+また、次の開発版となるNode.js v7.xは10月25日にリリースされる予定です。
+
+----
+
+[Migrating to Webpack 2](http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/ "Migrating to Webpack 2")という記事ではwebpack@2(まだβ版)へのマイグレーション方法について書かれています。
+
+webpackの公式サイトも新しくなりマイグレーションガイドがあるので合わせて読むと良いです。
+
+- [How to Upgrade from Webpack 1?](https://webpack.js.org/how-to/upgrade-from-webpack-1/ "How to Upgrade from Webpack 1?")
+
+webpack@2からは設定ファイルのバリデーションが入ったので、おかしな設定をするとエラーになります。
+マイグレーション時にエラーが出た場合は上記のガイドを見て直してみると良いです。
+
+細かい記述の変更も多いですが、`OccurrenceOrderPlugin`がデフォルトになったり、コマンドライン引数を取る方法などが追加されていたりもします。
+
+また、ES modulesをそのまま扱うことができるようになっているため、Babelの方でES modulesの変換を行わない設定などについても書かれています。
+
+```
+{
+  "presets": [
+    ["es2015", { "modules": false }]
+  ]
+}
+```
 
 ----
 <h1 class="site-genre">ヘッドライン</h1>
@@ -258,7 +305,7 @@ Babelを内蔵しasync/awaitなどを扱え、自動的に一定時間待つな�
 
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
 
-HTML 5 form validation APIをpolyfill/置き換える実装を持つフォームバリデーションライブラリ
+HTML5 form validation APIをpolyfill/置き換える実装を持つフォームバリデーションライブラリ
 
 ----
 <h1 class="site-genre">書籍関係</h1>


### PR DESCRIPTION
- [Release v4.0.0 · npm/npm](https://github.com/npm/npm/releases/tag/v4.0.0)
- [node-gakuen-201610.md](https://gist.github.com/othiym23/c98bd4ef5d9fb3f496835bd481ef40ae)
- [Node v6.9.0 (LTS) | Node.js](https://nodejs.org/en/blog/release/v6.9.0/)
- [Node.js v6 Transitions to LTS – Medium](https://medium.com/@nodejs/node-js-v6-transitions-to-lts-be7f18c17159#.c8d2tljbn)
- [webpack](https://webpack.js.org/how-to/upgrade-from-webpack-1/)
- [TestCafeでブラウザの自動テスト(E2Eテスト) | Web Scratch](http://efcl.info/2016/10/23/testcafe/)
- [Migrating to Webpack 2](http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/)
