### PR TITLE
2016-11-01のJavaScript

### DIFF
--- a/_i18n/ja/_posts/2016/2016-11-01-node.js-v7-node.js-v0.10-eol-webassembly-browser-preview.md
+++ b/_i18n/ja/_posts/2016/2016-11-01-node.js-v7-node.js-v0.10-eol-webassembly-browser-preview.md
@@ -1,0 +1,252 @@
+---
+title: "2016-11-01のJS: Node.js v7、Node.js v0.10 EOL、WebAssembly Browser Preview"
+author: azu
+layout: post
+date : 2016-11-01T09:57
+category: JSer
+tags:
+    - Node.js
+    - WebAssembly
+    - Browser
+
+---
+
+JSer.info #303　- Node.js
+
+
+----
+
+wasm - フィードバック期間
+
+- [WebAssembly](http://webassembly.org/community/feedback/)
+
+ブラウザのStatus
+
+- [V8 JavaScript Engine: WebAssembly Browser Preview](http://v8project.blogspot.jp/2016/10/webassembly-browser-preview.html)
+- [WebKit Feature Status | WebKit](https://webkit.org/status/#specification-webassembly)
+- [WebAssembly Browser Preview ★ Mozilla Hacks – the Web developer blog](https://hacks.mozilla.org/2016/10/webassembly-browser-preview/)
+- [A peek into the WebAssembly Browser Preview | Microsoft Edge Dev Blog](https://blogs.windows.com/msedgedev/2016/10/31/webassembly-browser-preview/)
+
+
+
+
+----
+<h1 class="site-genre">ヘッドライン</h1>
+
+----
+
+## Node v7.0.0 (Current) | Node.js
+[nodejs.org/en/blog/release/v7.0.0/](https://nodejs.org/en/blog/release/v7.0.0/ "Node v7.0.0 (Current) | Node.js")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">node.js</span> <span class="jser-tag">ReleaseNote</span></p>
+
+Node v7.0.0リリース。
+V8のアップデート、WHATWG URL Parserの試験的サポートなど
+
+----
+
+## 6.18.0 Released · Babel
+[babeljs.io/blog/2016/10/24/6.18.0](https://babeljs.io/blog/2016/10/24/6.18.0 "6.18.0 Released · Babel")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">babel</span> <span class="jser-tag">ReleaseNote</span></p>
+
+Babel v6.18.0リリース。
+`import()`のinitialサポート、`helper-builder-react-jsx`に`useBuiltIns`オプションの追加など
+
+----
+
+## Release Notes for Safari Technology Preview 16 | WebKit
+[webkit.org/blog/7030/release-notes-for-safari-technology-preview-16/](https://webkit.org/blog/7030/release-notes-for-safari-technology-preview-16/ "Release Notes for Safari Technology Preview 16 | WebKit")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">safari</span> <span class="jser-tag">URL</span> <span class="jser-tag">security</span></p>
+
+Safari Technology Preview Release 16リリース。
+URLのパースがウェブ標準により準拠するように、Gamepad APIのサポート、`Intl.getCanonicalLocales`のサポート、ES2016のnon-simple parametersにおけるearly errorに対応など
+
+----
+
+## ESLint v3.9.0 released - ESLint - Pluggable JavaScript linter
+[eslint.org/blog/2016/10/eslint-v3.9.0-released](http://eslint.org/blog/2016/10/eslint-v3.9.0-released "ESLint v3.9.0 released - ESLint - Pluggable JavaScript linter")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">ESLint</span> <span class="jser-tag">ReleaseNote</span></p>
+
+ESLint v3.9.0リリース。
+`codeframe` formatterの追加、カスタムパーサがルール向けに情報を提供するオブジェクト(`context.parserServices`)を定義できるようになるなど
+
+- [ESLint v3.9.0 - Qiita](http://qiita.com/mysticatea/items/abc7885b373b5b37ce97 "ESLint v3.9.0 - Qiita")
+- [Proposal for Parser Services · Issue #6974 · eslint/eslint](https://github.com/eslint/eslint/issues/6974 "Proposal for Parser Services · Issue #6974 · eslint/eslint")
+
+----
+<h1 class="site-genre">アーティクル</h1>
+
+----
+
+## Redux without React — State Management in Vanilla JavaScript
+[www.sitepoint.com/redux-without-react-state-management-vanilla-javascript/](https://www.sitepoint.com/redux-without-react-state-management-vanilla-javascript/ "Redux without React — State Management in Vanilla JavaScript")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">redux</span> <span class="jser-tag">JavaScript</span></p>
+
+Reactは使わずにReduxを扱ってみる話
+
+----
+
+## Visual Debugging with ES6 and Node.js – Good Eggs Product – Medium
+[medium.com/good-eggs-product/visual-debugging-with-es6-and-node-js-44631b3b040f](https://medium.com/good-eggs-product/visual-debugging-with-es6-and-node-js-44631b3b040f "Visual Debugging with ES6 and Node.js – Good Eggs Product – Medium")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">node.js</span> <span class="jser-tag">debug</span></p>
+
+Node.jsとBabelを組み合わせた場合のGUIデバッグ方法について
+
+----
+
+## V8 JavaScript Engine: WebAssembly Browser Preview
+[v8project.blogspot.com/2016/10/webassembly-browser-preview.html](http://v8project.blogspot.com/2016/10/webassembly-browser-preview.html "V8 JavaScript Engine: WebAssembly Browser Preview")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">WebAssembly</span> <span class="jser-tag">V8</span></p>
+
+Chromeがフラグ付きでWebAssernblyを実験的にサポート。フィードバックを募集している。
+
+- [WebAssembly](http://webassembly.org/roadmap/ "WebAssembly")
+
+----
+
+## Different ways to debug JavaScript code – Medium
+[medium.com/@sandeep.scet/different-ways-to-debug-javascript-code-579e7f58cf10](https://medium.com/@sandeep.scet/different-ways-to-debug-javascript-code-579e7f58cf10 "Different ways to debug JavaScript code – Medium")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">debug</span></p>
+
+JavaScriptのデバッグ手法について。
+alert、console、breakpoint、`debugger;`、`debug`、`monitor`などのAPIや方法について
+
+----
+
+## Node v7 で入った WHATWG URL 実装について | blog.jxck.io
+[blog.jxck.io/entries/2016-10-27/whatwg-url.html](https://blog.jxck.io/entries/2016-10-27/whatwg-url.html "Node v7 で入った WHATWG URL 実装について | blog.jxck.io")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">WHATWG</span> <span class="jser-tag">URL</span></p>
+
+Node.js v7で試験的に実装されたWHATWG URLについて
+
+----
+
+## ZEIT – Next.js
+[zeit.co/blog/next](https://zeit.co/blog/next "ZEIT – Next.js")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">React</span> <span class="jser-tag">serverless</span> <span class="jser-tag">isomorphic</span></p>
+
+Reactを使ったサーバサイドレンダリング向けのフレームワーク。
+CSS in JS、Head、ルーティングや開発ツールがセットになっている。
+
+----
+<h1 class="site-genre">スライド、動画関係</h1>
+
+----
+
+## Webpack &amp; React Performance in 16+ Steps
+[www.slideshare.net/grgur/webpack-react-performance-in-16-steps](http://www.slideshare.net/grgur/webpack-react-performance-in-16-steps "Webpack & React Performance in 16+ Steps")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">webpack</span> <span class="jser-tag">React</span> <span class="jser-tag">performance</span></p>
+
+webpackとReactでパフォーマンスやサイズなど気をつける点についてのスライド
+
+----
+<h1 class="site-genre">サイト、サービス、ドキュメント</h1>
+
+----
+
+## timarney/react-faq: A collection of links to help answer your questions about React.js
+[github.com/timarney/react-faq](https://github.com/timarney/react-faq "timarney/react-faq: A collection of links to help answer your questions about React.js")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">React</span></p>
+
+Reactに関するFAQをまとめたページ
+
+----
+
+## Performance  |  Web  |  Google Developers
+[developers.google.com/web/fundamentals/performance/](https://developers.google.com/web/fundamentals/performance/ "Performance  |  Web  |  Google Developers")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">browser</span> <span class="jser-tag">Chrome</span> <span class="jser-tag">document</span></p>
+
+ウェブサイトのパフォーマンス改善についてのドキュメント。
+クリティカルレンダリングパスの改善やネットワーク、アニメーションなど色々なパフォーマンスについての記事がまとめられている
+
+----
+
+## パフォーマンス - 開発ツール | MDN
+[developer.mozilla.org/ja/docs/Tools/Performance](https://developer.mozilla.org/ja/docs/Tools/Performance "パフォーマンス - 開発ツール | MDN")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">firefox</span> <span class="jser-tag">performance</span> <span class="jser-tag">document</span> <span class="jser-tag">browser</span> <span class="jser-tag">JavaScript</span></p>
+
+Firefoxの開発者ツールのリファレンスページ。
+基本的な使い方やツールの見方について。
+またカクカクなCSSアニメーション、UIスレッドをブロックしてしまうJSの問題などのシナリオ元にした改善方法についても書かれている
+
+----
+<h1 class="site-genre">ソフトウェア、ツール、ライブラリ関係</h1>
+
+----
+
+## pelotoncycle/resize-observer
+[github.com/pelotoncycle/resize-observer](https://github.com/pelotoncycle/resize-observer "pelotoncycle/resize-observer")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
+
+Resize Observerのpolyfill
+
+----
+
+## Raynos/jsig: From scratch type-checker
+[github.com/Raynos/jsig](https://github.com/Raynos/jsig "Raynos/jsig: From scratch type-checker")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">document</span> <span class="jser-tag">flowtype</span> <span class="jser-tag">Tools</span> <span class="jser-tag">TypeScript</span></p>
+
+JSDocのような型アノテーションコメントと型推論から静的な型チェックを行うツール。
+FlowTypeとは異なりES5に焦点をおいてる事と曖昧さを許容しない作り
+
+----
+
+## taichi/ci-yarn-upgrade: Keep NPM dependencies up-to-date with CI, providing version-to-version diff for each library
+[github.com/taichi/ci-yarn-upgrade](https://github.com/taichi/ci-yarn-upgrade "taichi/ci-yarn-upgrade: Keep NPM dependencies up-to-date with CI, providing version-to-version diff for each library")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">npm</span> <span class="jser-tag">Tools</span></p>
+
+yarnを使ってpackage.jsonの依存モジュールを更新するPRを出す事ができるツール。
+また更新するモジュールの一覧を取得する事もできる
+
+----
+
+## azu/ui-event-observer: Provide performant way to subscribe to browser UI Events.
+[github.com/azu/ui-event-observer](https://github.com/azu/ui-event-observer "azu/ui-event-observer: Provide performant way to subscribe to browser UI Events.")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
+
+同じ要素への同じイベントの複数の`addEventListener`を1つにまとめて扱うことができるライブラリ。
+
+----
+<h1 class="site-genre">書籍関係</h1>
+
+----
+
+## Modular JavaScript Book Series
+[mjavascript.com/](https://mjavascript.com/ "Modular JavaScript Book Series")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">book</span></p>
+
+クラウドファンディングで開始されたJavaScriptの書籍シリーズ
+
+- [Table of Contents — Practical ES6](https://ponyfoo.com/books/practical-es6/chapters#toc "Table of Contents — Practical ES6")
+
+----
+
+## 関数型プログラミングの基礎 JavaScriptを使って学ぶ : 立川察理, 長瀬嘉秀 : 本 : Amazon.co.jp
+[www.amazon.co.jp/%E9%96%A2%E6%95%B0%E5%9E%8B%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%9F%E3%83%B3%E3%82%B0%E3%81%AE%E5%9F%BA%E7%A4%8E-JavaScript%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E5%AD%A6%E3%81%B6-%E7%AB%8B%E5%B7%9D%E5%AF%9F%E7%90%86/dp/4865940596](https://www.amazon.co.jp/%E9%96%A2%E6%95%B0%E5%9E%8B%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%9F%E3%83%B3%E3%82%B0%E3%81%AE%E5%9F%BA%E7%A4%8E-JavaScript%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E5%AD%A6%E3%81%B6-%E7%AB%8B%E5%B7%9D%E5%AF%9F%E7%90%86/dp/4865940596 "関数型プログラミングの基礎 JavaScriptを使って学ぶ : 立川察理, 長瀬嘉秀 : 本 : Amazon.co.jp")
+
+<p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">関数型プログラミング</span> <span class="jser-tag">book</span></p>
+
+2016年10月29日発売
+JavaScriptでの関数型プログラミングについての書籍
+
+- [リックテレコム 書籍情報](http://www2.ric.co.jp/create/book/contents/book_1059.html "リックテレコム 書籍情報")
+
+----

--- a/_i18n/ja/_posts/2016/2016-11-01-node.js-v7-node.js-v0.10-eol-webassembly-browser-preview.md
+++ b/_i18n/ja/_posts/2016/2016-11-01-node.js-v7-node.js-v0.10-eol-webassembly-browser-preview.md
@@ -11,22 +11,38 @@ tags:
 
 ---
 
-JSer.info #303　- Node.js
+JSer.info #303　- 先週[Node.js v6.9.0 (LTS)](https://nodejs.org/en/blog/release/v6.9.0/ "Node v6.9.0 (LTS)")がリリースされましたが、開発版(LTSではない)である[Node v7.0.0](https://nodejs.org/en/blog/release/v7.0.0/ "Node.js v7.0.0")がリリースされました。
 
+V8のアップデート、WHATWG URLの試験的サポートなどが行われています。
 
+WHATWG URLについては以下の記事で解説されているので合わせて読んでみるといいです。
+
+- [Node v7 で入った WHATWG URL 実装について | blog.jxck.io](https://blog.jxck.io/entries/2016-10-27/whatwg-url.html "Node v7 で入った WHATWG URL 実装について | blog.jxck.io")
+
+また、2016-10-31でNode.js v0.10のメンテンスが終了し[EOL](https://ja.wikipedia.org/wiki/EOL "EOL")となります。
+
+![Node.js LTS timeline](https://monosnap.com/file/kkYTd5VdXRZOAJEebIvt8eWCk34Sb7.png)
+
+- [nodejs/LTS: Node.js Foundation Long-term Support Working Group](https://github.com/nodejs/LTS "nodejs/LTS: Node.js Foundation Long-term Support Working Group")
+
+Node.js v0.12も2016-12-31でメンテンスが終了するため、v4またはv6のActiveなLTSへ移行する必要があります。
 ----
 
-wasm - フィードバック期間
-
-- [WebAssembly](http://webassembly.org/community/feedback/)
-
-ブラウザのStatus
+[WebAssembly](http://webassembly.org/ "WebAssembly")が[Browser Preview](http://webassembly.org/roadmap/ "Browser Preview")のマイルストーンとなったため、各実装ブラウザで進捗に関する記事が公開されています。
 
 - [V8 JavaScript Engine: WebAssembly Browser Preview](http://v8project.blogspot.jp/2016/10/webassembly-browser-preview.html)
-- [WebKit Feature Status | WebKit](https://webkit.org/status/#specification-webassembly)
 - [WebAssembly Browser Preview ★ Mozilla Hacks – the Web developer blog](https://hacks.mozilla.org/2016/10/webassembly-browser-preview/)
 - [A peek into the WebAssembly Browser Preview | Microsoft Edge Dev Blog](https://blogs.windows.com/msedgedev/2016/10/31/webassembly-browser-preview/)
+- [WebKit Feature Status | WebKit](https://webkit.org/status/#specification-webassembly)
+  - WebKitは[前回と同様](https://jser.info/2016/03/17/react-webassembly-art-of-javascript/)にアナウンスは特にないですがStatusは**In Development**です
 
+それぞれの記事で試験的に利用する方法が書かれています。
+また、[Submitting Feedback & Issues](http://webassembly.org/community/feedback/ "Submitting Feedback &amp; Issues")にはそれぞれの実装や仕様に対するフィードバック先がまとめられています。
+
+> The tentative goal of the CG is for the Browser Preview to conclude in Q1 2017, though significant findings during the Browser Preview could potentially extend the duration
+> -- [Roadmap](http://webassembly.org/roadmap/ "Roadmap")
+
+今後のWebAssemblyコミュニティとしてのロードマップは[Roadmap](http://webassembly.org/roadmap/ "Roadmap")にかかれています。
 
 
 

--- a/_i18n/ja/_posts/2016/2016-11-01-node.js-v7-node.js-v0.10-eol-webassembly-browser-preview.md
+++ b/_i18n/ja/_posts/2016/2016-11-01-node.js-v7-node.js-v0.10-eol-webassembly-browser-preview.md
@@ -26,6 +26,7 @@ WHATWG URLについては以下の記事で解説されているので合わせ�
 - [nodejs/LTS: Node.js Foundation Long-term Support Working Group](https://github.com/nodejs/LTS "nodejs/LTS: Node.js Foundation Long-term Support Working Group")
 
 Node.js v0.12も2016-12-31でメンテンスが終了するため、v4またはv6のActiveなLTSへ移行する必要があります。
+
 ----
 
 [WebAssembly](http://webassembly.org/ "WebAssembly")が[Browser Preview](http://webassembly.org/roadmap/ "Browser Preview")のマイルストーンとなったため、各実装ブラウザで進捗に関する記事が公開されています。


### PR DESCRIPTION
Node

- [Node v7.0.0 (Current) | Node.js](https://nodejs.org/en/blog/release/v7.0.0/)
- [Node v7 で入った WHATWG URL 実装について | blog.jxck.io](https://blog.jxck.io/entries/2016-10-27/whatwg-url.html)
- [nodejs/LTS: Node.js Foundation Long-term Support Working Group](https://github.com/nodejs/LTS)


wasm

- [V8 JavaScript Engine: WebAssembly Browser Preview](http://v8project.blogspot.jp/2016/10/webassembly-browser-preview.html)
- [WebKit Feature Status | WebKit](https://webkit.org/status/#specification-webassembly)
- [WebAssembly Browser Preview ★ Mozilla Hacks – the Web developer blog](https://hacks.mozilla.org/2016/10/webassembly-browser-preview/)
- [WebAssembly](http://webassembly.org/community/feedback/)
- [A peek into the WebAssembly Browser Preview | Microsoft Edge Dev Blog](https://blogs.windows.com/msedgedev/2016/10/31/webassembly-browser-preview/#g80LOy0ottDuRvQo.97)
