### PR TITLE
Update 2018-10-16-node.js-v10.12.0inferno-v6.0.0tls-1.01.1.md

### DIFF
--- a/_i18n/ja/_posts/2018/2018-10-16-node.js-v10.12.0inferno-v6.0.0tls-1.01.1.md
+++ b/_i18n/ja/_posts/2018/2018-10-16-node.js-v10.12.0inferno-v6.0.0tls-1.01.1.md
@@ -92,7 +92,7 @@ Node.js 10.12.0リリース。
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">ESLint</span> <span class="jser-tag">ReleaseNote</span></p>
 
 ESLint v5.7.0リリース。
-`no-tabs`ルールに`allowIndentationTabs`オプションの追加、`camelcase`ルールに`ignoreList`オプションの追加など
+`no-tabs`ルールに`allowIndentationTabs`オプションの追加、`camelcase`ルールに`allow`オプションの追加など
 
 
 ----


### PR DESCRIPTION
ESLint の追加されたオプションの名前が異なっているのを修正する PR です。

リリース当初のリリースノートが間違っていた (https://github.com/eslint/eslint.github.io/pull/512) ので...。