### PR TITLE
Fix slack link

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,6 +26,7 @@
             target='blank'>
             <img src="/public/svg/slack.svg" alt="Slack" width="50" height="50"/>
             SlackにRSSを追加する
+        </a>
     </div>
     {% endif %}
     <nav>


### PR DESCRIPTION
検索フォームをクリックすると Slack のページに飛ばされます。
「Slack に RSS を追加する」リンクの閉じタグがないようです。