### PR TITLE
--experimental-json-modules フラグは削除されています

### DIFF
--- a/_i18n/ja/_posts/2019/2019-06-10-mathjs-v6modern-javascriptaudits-in-web-inspector.md
+++ b/_i18n/ja/_posts/2019/2019-06-10-mathjs-v6modern-javascriptaudits-in-web-inspector.md
@@ -59,7 +59,7 @@ console.log(log(10))
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">node.js</span> <span class="jser-tag">ReleaseNote</span></p>
 
 Node.js 12.4.0リリース。
-`import`文でJSONを読み込める` --experimental-json-modules`フラグの追加、V8 heap profilerを扱う`--heap-prof`フラグの追加など
+`import`文でJSONを読み込める` --experimental-json-modules`フラグの削除、V8 heap profilerを扱う`--heap-prof`フラグの追加など
 
 
 ----


### PR DESCRIPTION
`--experimental-modules` が有効になっている場合、 (ブラウザ側に合わせて)常にJSOM moduleが有効になったため、不要になった `--experimental-json-modules` フラグは削除されています。