### PR TITLE
Update 2019-12-17-npm-v6.13.4security-updatejson-parsewasi-on-node.js.md

### DIFF
--- a/_i18n/ja/_posts/2019/2019-12-17-npm-v6.13.4security-updatejson-parsewasi-on-node.js.md
+++ b/_i18n/ja/_posts/2019/2019-12-17-npm-v6.13.4security-updatejson-parsewasi-on-node.js.md
@@ -85,7 +85,7 @@ Preact 10.1.1リリース。
 
 npm 6.13.3以下に含まれていた脆弱性の対応のため、npm 6.13.4へのアップデートを含むNode.jsの各バージョンが2019-12-17リリースされる。
 
-- [The npm Blog — Binary Planting with the npm CLI](http://example.com/ "The npm Blog — Binary Planting with the npm CLI")
+- [The npm Blog — Binary Planting with the npm CLI](https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli "The npm Blog — Binary Planting with the npm CLI")
 - [Previous Releases | Node.js](https://nodejs.org/en/download/releases/ "Previous Releases | Node.js")
 
 ----


### PR DESCRIPTION
npmブログへのリンクが example.comになっていたので正しいURLに修正してみました。