### PR TITLE
fix typo

### DIFF
--- a/_i18n/ja/_posts/2020/2020-05-25-chrome-83-electron-9.0.0-typescript-eslint-3.0.0.md
+++ b/_i18n/ja/_posts/2020/2020-05-25-chrome-83-electron-9.0.0-typescript-eslint-3.0.0.md
@@ -217,7 +217,7 @@ WebGL/GLSLについてのチュートリアル
 [content.nuxtjs.org/](https://content.nuxtjs.org/ "Introduction - Nuxt Content")
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">Vue</span> <span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
 
-Nuxt.jsからMarkdown、JSON、CSVなどのコンテンツデータを取得して、埋め込めるNext.jsモジュール。
+Nuxt.jsからMarkdown、JSON、CSVなどのコンテンツデータを取得して、埋め込めるNuxt.jsモジュール。
 
 
 ----


### PR DESCRIPTION
Nuxt Contentの説明に「Next.jsモジュール」とありました。おそらく「Nuxt.jsモジュール」書き間違いでしょうかね。
ご確認のほどよろしくお願いします。