### PR TITLE
fix: typo in 2020-07-28-sveltetypescript-chrome-85-beta-web-speed-hackathon-online.md

### DIFF
--- a/_i18n/ja/_posts/2020/2020-07-28-sveltetypescript-chrome-85-beta-web-speed-hackathon-online.md
+++ b/_i18n/ja/_posts/2020/2020-07-28-sveltetypescript-chrome-85-beta-web-speed-hackathon-online.md
@@ -151,7 +151,7 @@ WebWorkerで利用できるAPIについてブラウザごとにまとめた対�
 [blog.joshuakgoldberg.com/ts-expect-error/](http://blog.joshuakgoldberg.com/ts-expect-error/ "TypeScript Contribution Diary: // @ts-expect-error | Goldblog")
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">TypeScript</span> <span class="jser-tag">article</span></p>
 
-`@ts-expect-error`wおどのように実装したのかについて
+`@ts-expect-error`をどのように実装したのかについて
 
 
 ----


### PR DESCRIPTION
「wお」を「を」に