### PR TITLE
Firefox 85についての情報の修正

### DIFF
--- a/_i18n/ja/_posts/2021/2021-02-02-webrtc-1.0-firefox-85-chrome-89-beta.md
+++ b/_i18n/ja/_posts/2021/2021-02-02-webrtc-1.0-firefox-85-chrome-89-beta.md
@@ -39,7 +39,6 @@ Flashのサポートを終了しています。
 - [Plugin Roadmap for Firefox - Plugins | MDN](https://developer.mozilla.org/en-US/docs/Plugins/Roadmap)
 
 CSSでPrefixなしの`:focus-visible`をサポート、`<link rel="preload">`をデフォルトでサポートしています。
-ES Proposal Stage 3のTop-Level awaitのサポート、`at()`メソッドのサポートなどが追加されています。
 また、キャッシュなどをつかったトラッキングを防止するためにNetwork partitioningの導入されています。
 
 - [Firefox 85 Cracks Down on Supercookies - Mozilla Security Blog](https://blog.mozilla.org/security/2021/01/26/supercookie-protections/)
@@ -70,7 +69,6 @@ Firefoxと同様にTop-Level awaitのサポートが追加されています。
 Firefox 85リリース。
 Flashのサポート終了。
 CSSでPrefixなしの`:focus-visible`をサポート、`<link rel="preload">`のサポート。
-ES Proposal Stage 3のTop-Level awaitのサポート、`at()`メソッドのサポートなど。
 また、Network partitioningの導入など
 
 - [Firefox 85.0, See All New Features, Updates and Fixes](https://www.mozilla.org/en-US/firefox/85.0/releasenotes/ "Firefox 85.0, See All New Features, Updates and Fixes")


### PR DESCRIPTION
> ES Proposal Stage 3のTop-Level awaitのサポート、at()メソッドのサポートなどが追加されています。

とありますが、これは間違いです。Firefox 85.0.1で`[ 0,1,2,3,4 ].at(1)`を実行すると`Uncaught TypeError: [...].at is not a function`となります。
[**Firefox 85 for developers - Mozilla | MDN**](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/85) にも載っていません。

Mozilla Hacks の [**January brings us Firefox 85**](https://hacks.mozilla.org/2021/01/january-brings-us-firefox-85/) にこの2つが書かれていて紛らわしいですが、恐らくその前のこの文を見落とされたのだと思います。  
> ## Nightly previews
> There are a couple of upcoming additions to Gecko that are currently available only in our Nightly Preview. 