### PR TITLE
Update 2021-05-18-node.js-14.17.0-typescript-4.3-rc-angular-v12.md

### DIFF
--- a/_i18n/ja/_posts/2021/2021-05-18-node.js-14.17.0-typescript-4.3-rc-angular-v12.md
+++ b/_i18n/ja/_posts/2021/2021-05-18-node.js-14.17.0-typescript-4.3-rc-angular-v12.md
@@ -141,7 +141,7 @@ Private Class Elements(fields/methods/accessors)のサポート、`static` Index
 
 Angular 12リリース。
 View Engineは非推奨となりIvyがデフォルトへと移行、Legacy i18n Message IDsからの移行ツール、インラインSaaSのサポートなど。
-TypeScript 4.2へのアップデート、webpack 5を実験的にサポート、IE 11サポートの非推奨化など
+TypeScript 4.2へのアップデート、webpack 5の正式サポート、IE 11サポートの非推奨化など
 
 - [Release 12.0.0 · angular/angular](https://github.com/angular/angular/releases/tag/12.0.0 "Release 12.0.0 · angular/angular")
 - [Angular - Migrating legacy localization IDs](https://angular.io/guide/migration-legacy-message-id "Angular - Migrating legacy localization IDs")

--- a/_i18n/ja/_posts/2021/2021-05-18-node.js-14.17.0-typescript-4.3-rc-angular-v12.md
+++ b/_i18n/ja/_posts/2021/2021-05-18-node.js-14.17.0-typescript-4.3-rc-angular-v12.md
@@ -80,7 +80,7 @@ IE 11のサポートはAngular 13で削除される予定です。
 
 - [RFC: Internet Explorer 11 support deprecation and removal · Issue #41840 · angular/angular](https://github.com/angular/angular/issues/41840)
 
-その他には、インラインSaaSのサポートなど。 TypeScript 4.2へのアップデート、webpack 5を実験的にサポートなども含まれています。
+その他には、インラインSaaSのサポートなど。 TypeScript 4.2へのアップデート、webpack 5の正式サポートなども含まれています。
 
 
 


### PR DESCRIPTION
Angular v12のwebpack 5サポートはv11で実験的だったものが正式サポートになるものです