### PR TITLE
2021-10-12のJS: npm 8.0.0(Node.js 16に同梱)、jQuery Mobileの非推奨化/jQuery UIはメンテナンスモードへ、ESLint 8

### DIFF
--- a/_i18n/ja/_posts/2021/2021-10-12-npm-8.0.0node.js-16-jquery-mobilejquery-ui-eslint-8.md
+++ b/_i18n/ja/_posts/2021/2021-10-12-npm-8.0.0node.js-16-jquery-mobilejquery-ui-eslint-8.md
@@ -13,17 +13,47 @@ tags:
 
 ---
 
-JSer.info #561 - - [Release v8.0.0 · npm/cli](https://github.com/npm/cli/releases/tag/v8.0.0)
-- [Node v16.11.0 (Current) | Node.js](https://nodejs.org/en/blog/release/v16.11.0/)
+JSer.info #561 - npm 8.0.0がリリースされました。
+
+- [Release v8.0.0 · npm/cli](https://github.com/npm/cli/releases/tag/v8.0.0)
+
+Node.js 10のサポート終了、Node.jsモジュール(`require("npm")`)として利用する方法がサポート終了となっています。
+
+既に[Node v16.11.0](https://nodejs.org/en/blog/release/v16.11.0/)に含まれているため、2021-10-26にリリース予定のNode.js 16 LTSにnpm 8が含まれる予定です。
+
+- [deps: `npm@8` · Issue #40168 · nodejs/node](https://github.com/nodejs/node/issues/40168)
 
 ---
 
+jQuery UI 1.13.0がリリースされました。
+
 - [jQuery UI 1.13.0 released | jQuery UI Blog](https://blog.jqueryui.com/2021/10/jquery-ui-1-13-0-released/)
+
+jQuery 1.7以下のサポートを終了し、1.8以降の最新のバージョンを含むjQueryに対応しています。
+
+このリリースをもって、jQuery UIはメンテナンスモードとなり、今後はバグ修正やセキュリティ修正などが中心となります。
+
+- [jQuery maintainers update and transition jQuery UI as part of overall modernization efforts | jQuery UI Blog](https://blog.jqueryui.com/2021/10/jquery-maintainers-update-and-transition-jquery-ui-as-part-of-overall-modernization-efforts/)
+
+また、同時にjQuery MobileはDeprecatedとなっています。
+
 - [jQuery maintainers continue modernization initiative with deprecation of jQuery Mobile - OpenJS Foundation](https://openjsf.org/blog/2021/10/07/deprecation-of-jquery-mobile/)
 
 ---
 
+ESLint 8.0.0がリリースされています。
+
 - [ESLint v8.0.0 released - ESLint - Pluggable JavaScript linter](https://eslint.org/blog/2021/10/eslint-v8.0.0-released)
+
+破壊的な変更としてNode 10のサポート終了、`codeframe`と`table`のフォーマッターをコアから削除、`eslint:recommended`の更新などが行われています。
+また、`ESLint`クラスを追加し`CLIEngine`クラスを削除、`eslint/lib`のエントリーポイントの削除、プラグインでも一部変更が含まれています。
+そのため、一部ルールがESLint 8では動かなくなっている可能性はありそうです。
+
+機能追加としてES2020のサポート、使われていない`eslint-disable`コメントを削除できるようになようになっています。
+
+マイグレーションガイドは次のページに公開されています。
+
+- [Migrating to v8.0.0 - ESLint - Pluggable JavaScript linter](https://eslint.org/docs/user-guide/migrating-to-8.0.0)
 
 
 ----


### PR DESCRIPTION
npm 8.0.0がリリースされました。

- [Release v8.0.0 · npm/cli](https://github.com/npm/cli/releases/tag/v8.0.0)

Node.js 10のサポート終了、Node.jsモジュール(`require("npm")`)として利用する方法がサポート終了となっています。

既に[Node v16.11.0](https://nodejs.org/en/blog/release/v16.11.0/)に含まれているため、2021-10-26にリリース予定のNode.js 16 LTSにnpm 8が含まれる予定です。

- [deps: `npm@8` · Issue #40168 · nodejs/node](https://github.com/nodejs/node/issues/40168)

---

jQuery UI 1.13.0がリリースされました。

- [jQuery UI 1.13.0 released | jQuery UI Blog](https://blog.jqueryui.com/2021/10/jquery-ui-1-13-0-released/)

jQuery 1.7以下のサポートを終了し、1.8以降の最新のバージョンを含むjQueryに対応しています。

このリリースをもって、jQuery UIはメンテナンスモードとなり、今後はバグ修正やセキュリティ修正などが中心となります。

- [jQuery maintainers update and transition jQuery UI as part of overall modernization efforts | jQuery UI Blog](https://blog.jqueryui.com/2021/10/jquery-maintainers-update-and-transition-jquery-ui-as-part-of-overall-modernization-efforts/)

また、同時にjQuery MobileはDeprecatedとなっています。

- [jQuery maintainers continue modernization initiative with deprecation of jQuery Mobile - OpenJS Foundation](https://openjsf.org/blog/2021/10/07/deprecation-of-jquery-mobile/)

---

ESLint 8.0.0がリリースされています。

- [ESLint v8.0.0 released - ESLint - Pluggable JavaScript linter](https://eslint.org/blog/2021/10/eslint-v8.0.0-released)

破壊的な変更としてNode 10のサポート終了、`codeframe`と`table`のフォーマッターをコアから削除、`eslint:recommended`の更新などが行われています。
また、`ESLint`クラスを追加し`CLIEngine`クラスを削除、`eslint/lib`のエントリーポイントの削除、プラグインでも一部変更が含まれています。
そのため、一部ルールがESLint 8では動かなくなっている可能性はありそうです。

機能追加としてES2020のサポート、使われていない`eslint-disable`コメントを削除できるようになようになっています。

マイグレーションガイドは次のページに公開されています。

- [Migrating to v8.0.0 - ESLint - Pluggable JavaScript linter](https://eslint.org/docs/user-guide/migrating-to-8.0.0)
