### PR TITLE
2021-10-27のJS: Yarn 3.1、Node.js 16.13.0(LTS)、Next.js 12

### DIFF
--- a/_i18n/ja/_posts/2021/2021-10-27-yarn-3.1-node.js-16.13.0lts-next.js-12.md
+++ b/_i18n/ja/_posts/2021/2021-10-27-yarn-3.1-node.js-16.13.0lts-next.js-12.md
@@ -13,10 +13,38 @@ tags:
 
 ---
 
-JSer.info #563 - - [Yarn 3.1 🎃👻 Corepack, ESM, pnpm, Optional Packages ... - DEV Community 👩‍💻👨‍💻](https://dev.to/arcanis/yarn-31-corepack-esm-pnpm-optional-packages--3hak)
+JSer.info #563 - Yarn 3.1がリリースされました。
+
+- [Yarn 3.1 🎃👻 Corepack, ESM, pnpm, Optional Packages ... - DEV Community 👩‍💻👨‍💻](https://dev.to/arcanis/yarn-31-corepack-esm-pnpm-optional-packages--3hak)
+- [berry/CHANGELOG.md at master · yarnpkg/berry](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#310 "berry/CHANGELOG.md at master · yarnpkg/berry")
+
+
+`yarn init -2`で[Node v16.9.0](https://nodejs.org/en/blog/release/v16.9.0/)からサポートされた[Corepack](https://nodejs.org/api/corepack.html)の`packageManager`フィールドに対応しています。
+
+また、PnPでのEMSサポート、新しいインストールモードとして`nodeLinker: pnpm`のサポートしています。
+また、`optionalDependencies`で指定したアーキテクチャだけをダウンロードする`supportedArchitectures`の設定を追加しています。いままでのYarnは`optionalDependencies`で指定された依存をすべてダウンロードしていたため、esbuildなどのアーキテクチャごとのバイナリを`optionalDependencies`でしているパッケージではダウンロードに時間がかかっていました。
+
+- [Different strategy for installing platform-specific binaries · Issue #789 · evanw/esbuild](https://github.com/evanw/esbuild/issues/789#issuecomment-901467782 "Different strategy for installing platform-specific binaries · Issue #789 · evanw/esbuild")
+
+----
+
+Node.js 16.13.0がリリースされました。このバージョンからNode.js 16.xのLTSが開始されます。
+
 - [Node v16.13.0 (LTS) | Node.js](https://nodejs.org/en/blog/release/v16.13.0/)
+
+Node.js 16.xのLTSは2024-04-30までメンテナンスがサポートされる予定です。
+
+- [Releases | Node.js](https://nodejs.org/en/about/releases/)
+
+----
+
+Next.js 12がリリースされました。
+
 - [Blog - Next.js 12 | Next.js](https://nextjs.org/blog/next-12)
 
+WCベースのビルドに対応、`pages/_middleware.js`を使ったMiddlwareの対応、React 18(Server-Side StreamingとReact Server Components)に対応しています。
+また、[webpackの`buildHttp`](https://github.com/webpack/webpack/projects/9)を使ったURL Importsに対応し、URLを直接ES Modulesとしてインポートし`next.lock`のロックファイルで管理できるようになります。
+また、クローラーbotに対するISRの最適化、AVIFの対応なども含まれています。
 
 ----
 


### PR DESCRIPTION
Yarn 3.1がリリースされました。

- [Yarn 3.1 🎃👻 Corepack, ESM, pnpm, Optional Packages ... - DEV Community 👩‍💻👨‍💻](https://dev.to/arcanis/yarn-31-corepack-esm-pnpm-optional-packages--3hak)
- [berry/CHANGELOG.md at master · yarnpkg/berry](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#310 "berry/CHANGELOG.md at master · yarnpkg/berry")


`yarn init -2`で[Node v16.9.0](https://nodejs.org/en/blog/release/v16.9.0/)からサポートされた[Corepack](https://nodejs.org/api/corepack.html)の`packageManager`フィールドに対応しています。

また、PnPでのEMSサポート、新しいインストールモードとして`nodeLinker: pnpm`のサポートしています。
また、`optionalDependencies`で指定したアーキテクチャだけをダウンロードする`supportedArchitectures`の設定を追加しています。いままでのYarnは`optionalDependencies`で指定された依存をすべてダウンロードしていたため、esbuildなどのアーキテクチャごとのバイナリを`optionalDependencies`でしているパッケージではダウンロードに時間がかかっていました。

- [Different strategy for installing platform-specific binaries · Issue #789 · evanw/esbuild](https://github.com/evanw/esbuild/issues/789#issuecomment-901467782 "Different strategy for installing platform-specific binaries · Issue #789 · evanw/esbuild")

----

Node.js 16.13.0がリリースされました。このバージョンからNode.js 16.xのLTSが開始されます。

- [Node v16.13.0 (LTS) | Node.js](https://nodejs.org/en/blog/release/v16.13.0/)

Node.js 16.xのLTSは2024-04-30までメンテナンスがサポートされる予定です。

- [Releases | Node.js](https://nodejs.org/en/about/releases/)

----

Next.js 12がリリースされました。

- [Blog - Next.js 12 | Next.js](https://nextjs.org/blog/next-12)

WCベースのビルドに対応、`pages/_middleware.js`を使ったMiddlwareの対応、React 18(Server-Side StreamingとReact Server Components)に対応しています。
また、[webpackの`buildHttp`](https://github.com/webpack/webpack/projects/9)を使ったURL Importsに対応し、URLを直接ES Modulesとしてインポートし`next.lock`のロックファイルで管理できるようになります。
また、クローラーbotに対するISRの最適化、AVIFの対応なども含まれています。