### PR TITLE
fix(2022-02-14): Firefox 97の項目からscroll-timelineの言及を削除

### DIFF
--- a/_i18n/ja/_posts/2022/2022-02-14-parcel-2.3.0-vite-2.8.0-angular-compiler-javascriptddd.md
+++ b/_i18n/ja/_posts/2022/2022-02-14-parcel-2.3.0-vite-2.8.0-angular-compiler-javascriptddd.md
@@ -174,7 +174,7 @@ ESLint 8.9.0リリース。
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">Firefox</span> <span class="jser-tag">ReleaseNote</span></p>
 
 Firefox 97リリース。
-CSSの`cap`と`ic` unitをサポート、`@scroll-timeline`と`animation-timeline`のサポート、CSS cascade layersをデフォルトで有効化。
+CSSの`cap`と`ic` unitをサポート、CSS cascade layersをデフォルトで有効化。
 `AbortController.abort()`/`AbortSignal.throwIfAborted()`/`AbortSignal.reason`プロパティのサポートなど
 
 - [Firefox 97 for developers - Mozilla | MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/97 "Firefox 97 for developers - Mozilla | MDN")


### PR DESCRIPTION
実装はされたんですが、フラグがついているもので、リリースされてはいないです。
MDNのほうでも項目が削除されています。
https://github.com/mdn/content/pull/12969