### PR TITLE
「2022-04-26のJS: Redux v4.2.0、Node.js 18、Jest 28」内のタイポ修正PRです

### DIFF
--- a/_i18n/ja/_posts/2022/2022-04-26-redux-v4.2.0-node.js-18-jest-28.md
+++ b/_i18n/ja/_posts/2022/2022-04-26-redux-v4.2.0-node.js-18-jest-28.md
@@ -41,7 +41,7 @@ Node.js 18がリリースされました。
 
 ----
 
-Jes 28がリリースされました。
+Jest 28がリリースされました。
 
 - [Jest 28: Shedding weight and improving compatibility 🫶 · Jest](https://jestjs.io/blog/2022/04/25/jest-28)
 - [jest/CHANGELOG.md at main · facebook/jest](https://github.com/facebook/jest/blob/main/CHANGELOG.md#2800)


### PR DESCRIPTION
```
Jes 28がリリースされました。
```
↓
```
Jest 28がリリースされました。
```