### PR TITLE
2022-12-20のJS: Vite 4.0、SvelteKit 1.0、Node v19.3.0(npm 9)、RUM Archive

### DIFF
--- a/_i18n/ja/_posts/2022/2022-12-20-vite-4.0-sveltekit-1.0-node-v19.3.0npm-9-rum-archive.md
+++ b/_i18n/ja/_posts/2022/2022-12-20-vite-4.0-sveltekit-1.0-node-v19.3.0npm-9-rum-archive.md
@@ -44,7 +44,7 @@ npm 8から9はメジャーアップデートなので、破壊的な変更を�
 
 - [Plans for npm 9 · Issue #778 · nodejs/Release](https://github.com/nodejs/Release/issues/778)
 
-議論した結果、次のようなガイドラインが作成され、そのガイドラインを満たしているなら、Node.jsのメジャーアップデートなしに同梱するnpmをメジャーアップデートするという結論になったようです。
+議論した結果、次のようなガイドラインが作成され、このガイドラインを満たしているなら、Node.jsのメジャーアップデートなしに同梱するnpmをメジャーアップデートするという結論になったようです。
 具体的にはNode.jsのエコシステムをテストする[citgm](https://github.com/nodejs/citgm)がfailしない、`package-lock.json`を変更しないなどの要件が含まれています。
 
 - [Integrating with node · npm/cli Wiki](https://github.com/npm/cli/wiki/Integrating-with-node)


### PR DESCRIPTION
Vite 4.0がリリースされました。

- [Vite 4.0 is out! | Vite](https://vitejs.dev/blog/announcing-vite4.html)

SWCをサポートする`@vitejs/plugin-react-swc`を追加、デフォルトでES2020形式で出力するように変更、CSSを文字列としてインポートする方法の変更などの変更が含まれています。

---

[Svelte](https://svelte.dev/)ベースのフレームワークであるSvelteKit 1.0がリリースされました。

- [Announcing SvelteKit 1.0](https://svelte.dev/blog/announcing-sveltekit-1.0)

α版からの変更点は次のマイグレーションガイドにまとめられています。

- [Migration guide · Discussion #5774 · sveltejs/kit](https://github.com/sveltejs/kit/discussions/5774)

---

Node v19.3.0がリリースされました。

- [Node v19.3.0 (Current) | Node.js](https://nodejs.org/en/blog/release/v19.3.0/)

Node v19.3.0では、npm 9系となるnpm 9.2.0が同梱されています。
npm 8から9はメジャーアップデートなので、破壊的な変更を含んでいます。

- [npm v9.0.0 released | GitHub Changelog](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/)

一方で、Node.jsに同梱されるnpmをアップデートする際にどうするかについて、次のIssueで議論されました。

- [Plans for npm 9 · Issue #778 · nodejs/Release](https://github.com/nodejs/Release/issues/778)

議論した結果、次のようなガイドラインが作成され、このガイドラインを満たしているなら、Node.jsのメジャーアップデートなしに同梱するnpmをメジャーアップデートするという結論になったようです。
具体的にはNode.jsのエコシステムをテストする[citgm](https://github.com/nodejs/citgm)がfailしない、`package-lock.json`を変更しないなどの要件が含まれています。

- [Integrating with node · npm/cli Wiki](https://github.com/npm/cli/wiki/Integrating-with-node)

このガイドラインに則り、2023年1月18日にnpm 9をNode.js 18へもバックポートする予定となっています。

> Wednesday Jan. 18th (~6 weeks after node@19 backport) 
> A PR will be opened to backport npm@9.x in node@18
> https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/
