### PR TITLE
Fixed typo `StroyObj` → `StoryObj`

### DIFF
--- a/_i18n/ja/_posts/2023/2023-02-15-lighthouse-10-core-js-webcontainers.md
+++ b/_i18n/ja/_posts/2023/2023-02-15-lighthouse-10-core-js-webcontainers.md
@@ -210,7 +210,7 @@ Prerenderした場合の`navigationStart`は事前実行のタイミングとな
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">TypeScript</span> <span class="jser-tag">article</span></p>
 
 Storybook 7でのTypeScriptの型について。
-`StroyObj`タイプや`satisfies`演算子を使ってexportするコンポーネントの定義に型を付ける話
+`StoryObj`タイプや`satisfies`演算子を使ってexportするコンポーネントの定義に型を付ける話
 
 
 ----

--- a/_i18n/ko/_posts/2023/2023-02-15-lighthouse-10-core-js-webcontainers.md
+++ b/_i18n/ko/_posts/2023/2023-02-15-lighthouse-10-core-js-webcontainers.md
@@ -211,7 +211,7 @@ Prerender한 경우 `navigationStart`는 사전실행 타이밍이기 되기에,
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">TypeScript</span> <span class="jser-tag">article</span></p>
 
 Storybook 7의 TypeScript 자료형에 대해.
-`StroyObj` 타입이나 `satisfies` 연산자를 사용해 export 하는 컴포넌트 정의에 자료형을 붙이는 글
+`StoryObj` 타입이나 `satisfies` 연산자를 사용해 export 하는 컴포넌트 정의에 자료형을 붙이는 글
 
 
 ----


### PR DESCRIPTION
`StroyObj` → `StoryObj` に修正しました。
参考文献: https://storybook.js.org/docs/react/api/csf