### PR TITLE
Fix typo(リフレットレート→リフレッシュレート)

### DIFF
--- a/_i18n/ja/_posts/2023/2023-04-30-vite-4.3-deno-1.33-node.js-1418.md
+++ b/_i18n/ja/_posts/2023/2023-04-30-vite-4.3-deno-1.33-node.js-1418.md
@@ -145,7 +145,7 @@ npmパッケージが、どのソースコードのコミット、ビルドの�
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">CSS</span> <span class="jser-tag">article</span></p>
 
 `update` Media Queryについて。
-デバイスのリフレットレートが`fast`/`slow`/`none`かを判定したスタイルを書ける。
+デバイスのリフレッシュレートが`fast`/`slow`/`none`かを判定したスタイルを書ける。
 
 
 ----


### PR DESCRIPTION
`リフレットレート` → `リフレッシュレート` に修正しました。