### PR TITLE
sideways-{lr,lr}をsideways-{rl,lr}に修正する

### DIFF
--- a/_i18n/ja/_posts/2025/2025-01-23-vitest-3.0-rspack-1.2-react-server.md
+++ b/_i18n/ja/_posts/2025/2025-01-23-vitest-3.0-rspack-1.2-react-server.md
@@ -77,7 +77,7 @@ React Native Webをサポートなど
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">Chrome</span> <span class="jser-tag">ReleaseNote</span></p>
 
 Chrome 132リリース。
-`<dialog>`の`toggle`イベントをサポート、CSSの`writing-mode`が`sideways-{lr,lr}`(横書きモード)をサポート。
+`<dialog>`の`toggle`イベントをサポート、CSSの`writing-mode`が`sideways-{rl,lr}`(横書きモード)をサポート。
 `Request.bytes()`/`Response.bytes()`をサポート、すべての画面をキャプチャする`getAllScreensMedia()`のサポート、Element captureのサポート。
 Origin TrialとしてExplicit compile hints with magic comments、`Document-Isolation-Policy`のサポートなど
 

--- a/_i18n/ko/_posts/2025/2025-01-23-vitest-3.0-rspack-1.2-react-server.md
+++ b/_i18n/ko/_posts/2025/2025-01-23-vitest-3.0-rspack-1.2-react-server.md
@@ -78,7 +78,7 @@ React Native Web 지원
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">Chrome</span> <span class="jser-tag">ReleaseNote</span></p>
 
 Chrome 132 출시.
-`<dialog>`의 `toggle` 이벤트 지원, CSS의 `writing-mode`가 `sideways-{lr,lr}` 지원.
+`<dialog>`의 `toggle` 이벤트 지원, CSS의 `writing-mode`가 `sideways-{rl,lr}` 지원.
 `Request.bytes()`/`Response.bytes()` 지원, 모든 화면 캡쳐하는 `getAllScreensMedia()` 지원, Element capture 지원.
 Origin Trial로 Explicit compile hints with magic comments, `Document-Isolation-Policy` 지원
 


### PR DESCRIPTION
どちらもlrになっていたので片方をrlに変更しました。

順番はChromeのBlogに合わせました。
> Support for [sideways-rl and sideways-lr](https://developer.mozilla.org/docs/Web/CSS/writing-mode#values) keywords for the writing-mode CSS property.