### PR TITLE
Fix a slide link in `2025-05-25-jser-14th.md`

### DIFF
--- a/_i18n/ja/_posts/2025/2025-05-25-jser-14th.md
+++ b/_i18n/ja/_posts/2025/2025-05-25-jser-14th.md
@@ -82,7 +82,7 @@ ESLintの大きな特徴としてプラグインでルールを追加できる�
 
 そのため、JavaScript以外の言語で書かれたLinterでは、プラグインをどう扱うかが大きな課題となっています。それぞれのLinterでアプローチが異なりますが、それぞれのLinterがプラグインサポートの仕組みを開発しています。
 
-- [Exploring Type-Informed Lint Rules in Rust based TypeScript Linters - Speaker Deck](https://speakerdeck.com/unvalley/exploring-type-informed-lint-rules-in-rust-based-linters)
+- [Plugin System in Rust based JavaScript/TypeScript Linters - Speaker Deck](https://speakerdeck.com/unvalley/typescript-linters)
 
 一方で、ESLintはHTMLやCSSといったJavaScript以外の言語も扱えるようなlanguage-agnostic linterとなる方向性を示しています。
 


### PR DESCRIPTION
I think it should be [Plugin System in Rust based JavaScript / TypeScript Linters](https://speakerdeck.com/unvalley/typescript-linters) instead of [Exploring Type-Informed Lint Rules in Rust based TypeScript Linters](https://speakerdeck.com/unvalley/exploring-type-informed-lint-rules-in-rust-based-linters)

Anyway thanks for the reference, and congrats 14th anniversary!