### PR TITLE
2025-07-04の記事の変更

### DIFF
--- a/_i18n/ja/_posts/2025/2025-07-04-ecmascript-2025-rspack-1.4-deno-2.4-bundle-size.md
+++ b/_i18n/ja/_posts/2025/2025-07-04-ecmascript-2025-rspack-1.4-deno-2.4-bundle-size.md
@@ -211,6 +211,6 @@ React の`useOptimistic` hooks の使い方や`setState`との違いについて
 
 <p class="jser-tags jser-tag-icon"><span class="jser-tag">JavaScript</span> <span class="jser-tag">library</span></p>
 
-緯度経度から地名を検索するライブラリ
+緯度経度からタイムゾーンを検索するライブラリ
 
 ---


### PR DESCRIPTION
tz-lookupの主目的は「緯度経度からタイムゾーンを検索する」ものです。おおよその地名を知ることができるのはあくまでタイムゾーンと地名がある程度関連づいているからです。