### PR TITLE
2025-09-09のJS: Zod 4.1.0、`debug`や`chalk`パッケージの侵害、monorepoなアプリを`node --experimental-strip-types`に移行

### DIFF
--- a/_i18n/ja/_posts/2025/2025-09-09-zod-4.1.0-debugchalk-monoreponode-experimental-strip-types.md
+++ b/_i18n/ja/_posts/2025/2025-09-09-zod-4.1.0-debugchalk-monoreponode-experimental-strip-types.md
@@ -2,7 +2,7 @@
 title: "2025-09-09のJS: Zod 4.1.0、`debug`や`chalk`パッケージの侵害、monorepoなアプリを`node --experimental-strip-types`へ移行"
 author: "azu"
 layout: post
-date: 2025-09-09T08:23:06.859Z
+date: 2025-09-09T09:02:57.249Z
 category: JSer
 tags:
 - TypeScript


### PR DESCRIPTION

https://github.com/colinhacks/zod/releases/tag/v4.1.0
https://colinhacks.com/essays/introducing-zod-codecs


---

https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised
https://efcl.info/2025/09/07/npm-oidc/

---

https://blog.calm.com/engineering/how-we-migrated-our-rushjs-monorepo-to-node-type-stripping