### PR TITLE
PR bodyの上書きを修正

### DIFF
--- a/actions/update-draft-pr/src/rename.ts
+++ b/actions/update-draft-pr/src/rename.ts
@@ -20,9 +20,23 @@ interface EmbedHeadlineParams {
     headline?: string;
 }
 
+const HEADLINE_SECTION_PATTERN = /---\s+JSer\.info #\d+(?:\s+-\s+)?\s*([\s\S]*?)\s*----/;
+
+const hasExistingHeadline = (content: string): boolean => {
+    const match = content.match(HEADLINE_SECTION_PATTERN);
+    if (!match) {
+        return false;
+    }
+    return match[1].trim().length > 0;
+};
+
 const embedHeadline = ({ content, headline }: EmbedHeadlineParams): string => {
     if (!headline) {
         console.log("headline is not defined");
+        return content;
+    }
+    if (hasExistingHeadline(content)) {
+        console.log("headline is already written in content; skip overwrite");
         return content;
     }
     console.log("# headline")


### PR DESCRIPTION
ドラフトPRのbodyからヘッドラインを埋め込む処理で、すでにファイル側に
ヘッドラインが書かれている場合は上書きしないようにする。

Co-authored-by: azu <azu@users.noreply.github.com>