### PR TITLE
fix: rss-to-bluesky のXMLエンティティ展開上限を無効化

### DIFF
--- a/.github/workflows/rss-to-bluesky.yml
+++ b/.github/workflows/rss-to-bluesky.yml
@@ -40,6 +40,7 @@ jobs:
           password: ${{ secrets.JSER_BLUESKY_PASSWORD }}
           cache-file: ${{ github.workspace }}/blueskyfeedbot/cache.json
           initial-post-limit: 1
+          xml-entity-expansion-limit: 0
 
   jser:
     runs-on: ubuntu-latest
@@ -73,3 +74,4 @@ jobs:
           password: ${{ secrets.JSER_BLUESKY_PASSWORD }}
           cache-file: ${{ github.workspace }}/blueskyfeedbot/cache.json
           initial-post-limit: 1
+          xml-entity-expansion-limit: 0


### PR DESCRIPTION
## Summary

`rss-to-bluesky` ワークフローでXMLエンティティ展開の上限値を `0`（無制限）に設定する。RSSフィードのサイズ増加に伴うパース失敗を回避する目的。

## Changes

- `.github/workflows/rss-to-bluesky.yml` の `jser-products` と `jser` 両ジョブに `xml-entity-expansion-limit: 0` を追加

## Breaking Changes

None

## Test Plan

- [ ] ワークフロー実行時に `rss-to-bluesky` のRSSパースが成功すること
- [ ] BlueskyへのRSS投稿が正常に行われること